### PR TITLE
feat: implement starlog command for saving commits

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ docs/_build/
 NAMING_MAP.md
 build.sh
 PROJECT_COMMANDS.md
+DEV_DIARY.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,13 +29,30 @@ This document outlines planned features, enhancements, and edge cases for the ru
 - Case sensitivity: Handle differences in filesystem case sensitivity.
 - Non-UTF8 filenames: Support unusual filename encodings.
 
+### 3. `ruxpy course` Branch Management
+- `ruxpy course -l`: List all branches ("courses") in the repository.
+- `ruxpy course -sw <branch>`: Switch to a particular branch.
+- `ruxpy course -c <branch>`: Create a new branch.
+
+
+### 4. `ruxpy starlog`
+- `ruxpy starlog -l`: List all starlogs (commits) in the repository.
+- Interactive commit message: If `ruxpy starlog -c` is run without `-m`, open the default editor for the user to enter a commit message (similar to git).
+- Support for `-m` flag: Allow `ruxpy starlog -c -m "message"` or `ruxpy starlog -cm "message"` to commit with a message directly from the terminal.
+
 ## Future Enhancements
+
 - Branch management and switching
 - Diff and patch generation
 - Merge and conflict resolution
 - Commit signing and verification
 - Integration with remote repositories
 - Advanced logging and history visualization
+
+## Deployment & Release Plan
+
+- Plan to package and release ruxpy as a Nix package for easy installation and usage across platforms.
+- Provide reproducible development and deployment environments using Nix.
 
 ---
 

--- a/ruxpy/__init__.py
+++ b/ruxpy/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.1.0"
 
 # Import Rust extension and expose its functions
-from .ruxpy import init_object_dir, save_blob, read_blob
+from .ruxpy import init_object_dir, save_blob, read_blob, save_starlog
 
-__all__ = ["init_object_dir", "save_blob", "read_blob"]
+__all__ = ["init_object_dir", "save_blob", "read_blob", "save_starlog"]

--- a/ruxpy/cli.py
+++ b/ruxpy/cli.py
@@ -1,6 +1,7 @@
 import click
 import os
 import json
+from ruxpy import ruxpy
 
 
 @click.group()
@@ -23,6 +24,9 @@ def start(path):
         return
     else:
         os.makedirs(dock_path, exist_ok=True)
+
+        # Create the objects dir
+        ruxpy.init_object_dir(dir_path)
 
         # Create config.toml
         config_path = os.path.join(dock_path, "config.toml")
@@ -73,6 +77,7 @@ def beam(files):
     except (FileNotFoundError, json.JSONDecodeError):
         staged_files = []
 
+    # only append if its not staged previously
     for file in files:
         if file not in staged_files:
             staged_files.append(file)

--- a/ruxpy/utility.py
+++ b/ruxpy/utility.py
@@ -3,6 +3,19 @@ import json
 from typing import List
 
 
+def get_paths(base_path):
+    paths = {}
+    paths["repo"] = base_path
+    paths["dock"] = os.path.join(base_path, ".dock")
+    paths["stage"] = os.path.join(paths["dock"], "stage")
+    paths["helm"] = os.path.join(paths["dock"], "HELM")
+    paths["links"] = os.path.join(paths["dock"], "links")
+    paths["core"] = os.path.join(paths["links"], "helm", "core")
+    paths["config"] = os.path.join(paths["dock"], "config.toml")
+    paths["objects"] = os.path.join(paths["dock"], "objects")
+    return paths
+
+
 def list_repo_files(repo_path) -> List[str]:
     files: List[str] = []
     for root, dirs, filenames in os.walk(repo_path):

--- a/ruxpy/utility.py
+++ b/ruxpy/utility.py
@@ -1,0 +1,39 @@
+import os
+import json
+from typing import List
+
+
+def list_repo_files(repo_path) -> List[str]:
+    files: List[str] = []
+    for root, dirs, filenames in os.walk(repo_path):
+        # Skip internal directories
+        if ".dock" in root or "__pycache__" in root:
+            continue
+        for filename in filenames:
+            # Get relative path
+            rel_path = os.path.relpath(os.path.join(root, filename), repo_path)
+            files.append(rel_path)
+    return files
+
+
+def list_staged_files(stage_path):
+    try:
+        with open(stage_path, "r") as f:
+            staged_files = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        staged_files = []
+    return staged_files
+
+
+def list_unstaged_files(repo_path: str):
+    all_files = list_repo_files(repo_path)
+
+    stage_path = os.path.join(repo_path, ".dock", "stage")
+    staged_files = list_staged_files(stage_path)
+
+    unstaged_files = []
+    for file in all_files:
+        if file not in staged_files:
+            unstaged_files.append(file)
+
+    return unstaged_files

--- a/tests/test_starlog.py
+++ b/tests/test_starlog.py
@@ -1,0 +1,30 @@
+import os
+import json
+from ruxpy.cli import main
+from click.testing import CliRunner
+
+
+def test_starlog_command(tmp_path):
+    repo = tmp_path / "repo"
+    os.makedirs(repo)
+    os.chdir(repo)
+    runner = CliRunner()
+    runner.invoke(main, ["start", str(repo)])
+
+    # Create and stage files
+    (repo / "file1.txt").write_text("hello")
+    (repo / ".conf").mkdir(parents=True, exist_ok=True)
+    (repo / ".conf" / "config.py").write_text("set_key=7ash2bs23basd")
+    runner.invoke(main, ["beam", "file1.txt", ".conf/config.py"])
+
+    # Run starlog
+    result = runner.invoke(main, ["starlog", "-cm", "Test commit"])
+    assert result.exit_code == 0
+
+    # Check starlog file exists
+    starlogs_dir = repo / ".dock" / "starlogs"
+    assert any(starlogs_dir.iterdir())
+
+    # Check stage file is cleared
+    with open(repo / ".dock" / "stage") as f:
+        assert json.load(f) == []

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,57 @@
+import os
+from ruxpy.cli import main
+from ruxpy.utility import list_repo_files, list_staged_files, list_unstaged_files
+from click.testing import CliRunner
+
+
+def test_list_staged_files(tmp_path):
+    test_repo = tmp_path / "repo"
+    os.makedirs(test_repo)
+    os.chdir(test_repo)
+
+    runner = CliRunner()
+    runner.invoke(main, ["start", str(test_repo)])
+
+    (test_repo / "file1.txt").write_text("hello")
+    (test_repo / "file2.txt").write_text("world")
+
+    runner.invoke(main, ["beam", "file1.txt", "file2.txt"])
+
+    staged_path = os.path.join(test_repo, ".dock", "stage")
+    staged_files = list_staged_files(staged_path)
+
+    assert set(staged_files) == {"file1.txt", "file2.txt"}
+
+
+def test_list_unstaged_files(tmp_path):
+    test_repo = tmp_path / "repo"
+    os.makedirs(test_repo)
+    os.chdir(test_repo)
+
+    runner = CliRunner()
+    runner.invoke(main, ["start", str(test_repo)])
+
+    (test_repo / "file1.txt").write_text("hello")
+    (test_repo / "file2.txt").write_text("world")
+
+    runner.invoke(main, ["beam", "file1.txt"])
+
+    unstaged_files = list_unstaged_files(test_repo)
+    assert unstaged_files == ["file2.txt"]
+
+
+def test_list_repo_files(tmp_path):
+    test_repo = tmp_path / "repo"
+    os.makedirs(test_repo)
+    os.chdir(test_repo)
+
+    runner = CliRunner()
+    runner.invoke(main, ["start", str(test_repo)])
+
+    (test_repo / "file1.txt").write_text("hello")
+    (test_repo / "file2.txt").write_text("world")
+    (test_repo / "src").mkdir(parents=True, exist_ok=True)
+    (test_repo / "src" / "file1.txt").write_text("Hello World")
+
+    all_files = list_repo_files(test_repo)
+    assert set(all_files) == {"file1.txt", "file2.txt", "src/file1.txt"}


### PR DESCRIPTION
## Description
This PR introduces the `starlog` command, enabling users to commit staged files in ruxpy.

- Adds a robust commit workflow: collects staged files, saves their blobs, gathers commit metadata (message, author, timestamp, parent), and serializes the commit object
- Stores commit objects in `starlogs` using a split-hash directory structure
- Updates branch pointers to reference the latest commit
- Clears the staging area after each commit
- Handles repo initialization checks and user feedback
- Includes supporting Rust logic for saving and hashing commit objects

This completes the core commit functionality for ruxpy and lays the foundation for future features like history, branching, and status.

