### PR TITLE
feat: add ruxpy config command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,10 +49,26 @@ This document outlines planned features, enhancements, and edge cases for the ru
 - Integration with remote repositories
 - Advanced logging and history visualization
 
+- Config command improvements:
+  - Validation for config fields (e.g. email format, non-empty username/name)
+  - User feedback when no options are provided (show current config or helpful message)
+
+
 ## Deployment & Release Plan
 
 - Plan to package and release ruxpy as a Nix package for easy installation and usage across platforms.
 - Provide reproducible development and deployment environments using Nix.
+
+## Data Integrity & Atomic Writes
+
+To ensure robust data integrity, implement atomic write operations for critical storage paths:
+
+- Object store (blob storage):
+  - Use atomic file writes to prevent corruption or partial writes during blob save operations.
+- Starlog store (commit storage):
+  - Apply atomic writes when saving starlogs to guarantee commit consistency.
+
+Note: While atomic writes are less critical for config updates, they are essential for object and commit storage to avoid data loss or corruption in case of crashes or interruptions.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "flake8>=5.0.4",
     "pre-commit>=3.5.0",
     "pytest>=8.3.5",
+    "toml>=0.10.2",
+    "tomlkit>=0.13.3",
 ]
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/ruxpy/cli.py
+++ b/ruxpy/cli.py
@@ -169,8 +169,22 @@ Files yet to be beamed:
             return
 
         if message:
-            author = "Jean-Luc Picard"
-            email = "picard@starfleet.com"
+            # Gather config metadata
+            config_path = paths["config"]
+            with open(config_path, "r") as f:
+                config = tomlkit.parse(f.read())
+
+            try:
+                author = config["name"]
+                email = config["email"]
+            except exceptions.NonExistentKey:
+                click.echo(
+                    f"{click.style('[ERROR]', fg="red")} "
+                    "Please set name and email for starlogs\n"
+                    " (Use ruxpy config -sn <name> -se <email>)"
+                )
+                return
+
             timestamp = datetime.now().isoformat()
 
             staged_hash_list = {}

--- a/ruxpy/cli.py
+++ b/ruxpy/cli.py
@@ -1,6 +1,8 @@
 import click
 import os
 import json
+import tomlkit
+from tomlkit import exceptions
 from datetime import datetime
 from ruxpy import ruxpy
 from .utility import list_unstaged_files, list_staged_files, get_paths
@@ -11,6 +13,39 @@ from .utility import list_unstaged_files, list_staged_files, get_paths
 def main():
     """Ruxpy - A hybrid Rust/Python version control system"""
     pass
+
+
+@main.command("config")
+@click.option("-su", "--set-username", help="Set username in the config")
+@click.option("-se", "--set-email", help="Set email in the config")
+@click.option("-sn", "--set-name", help="Set name in the config")
+def config(set_username, set_email, set_name):
+    base_path = os.getcwd()
+    config_path = get_paths(base_path)["config"]
+
+    try:
+        with open(config_path, "r") as f:
+            config = tomlkit.parse(f.read())
+    except (FileNotFoundError, exceptions.ParseError):
+        click.echo(
+            f"{click.style('[ERROR]', fg="red")} "
+            "Spacedock is not initialized. No .dock/ found."
+        )
+        return
+
+    if set_username:
+        config["username"] = set_username
+    if set_email:
+        config["email"] = set_email
+    if set_name:
+        config["name"] = set_name
+
+    with open(config_path, "w") as f:
+        f.write(tomlkit.dumps(config))
+
+    click.echo(
+        f"{click.style('[SUCCESS]', fg="green")} " "Config updated successfully!"
+    )
 
 
 @main.command("start")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,21 @@
 import os
 import json
+import tomlkit
+import pytest
 from click.testing import CliRunner
 from ruxpy.cli import main
+
+
+@pytest.fixture
+def init_repo(tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.chdir(repo_path)
+        result = runner.invoke(main, ["start"])
+        assert result.exit_code == 0
+        yield repo_path
 
 
 def test_start_creates_dock(tmp_path):
@@ -15,27 +29,18 @@ def test_start_creates_dock(tmp_path):
     assert (test_repo / ".dock" / "HELM").exists()
 
 
-def test_scan_shows_status(tmp_path):
-    test_repo = tmp_path / "repo"
+def test_scan_shows_status(init_repo):
+    _ = init_repo
     runner = CliRunner()
-    runner.invoke(main, ["start", str(test_repo)])
-
-    # Change working directory to test_repo
-    with runner.isolated_filesystem():
-        os.chdir(test_repo)
-        result = runner.invoke(main, ["scan"])
-        assert result.exit_code == 0
-        assert "On branch '-core-'" in result.output
-        assert "Spacedock clear, no starlog updates required." in result.output
+    result = runner.invoke(main, ["scan"])
+    assert result.exit_code == 0
+    assert "On branch '-core-'" in result.output
+    assert "Spacedock clear, no starlog updates required." in result.output
 
 
-def test_beam_stages_files(tmp_path):
+def test_beam_stages_files(init_repo):
+    repo_path = init_repo
     runner = CliRunner()
-    repo_path = tmp_path / "repo"
-    os.makedirs(repo_path)
-    os.chdir(repo_path)
-    # Initialize repo
-    runner.invoke(main, ["start"])
     # Create test files
     (repo_path / "file1.txt").write_text("hello")
     (repo_path / "file2.txt").write_text("world")
@@ -47,3 +52,81 @@ def test_beam_stages_files(tmp_path):
         staged = json.load(f)
     assert "file1.txt" in staged
     assert "file2.txt" in staged
+
+
+def test_set_config_individual(init_repo):
+    repo_path = init_repo
+    runner = CliRunner()
+
+    runner.invoke(main, ["config", "-se", "picard@gmail.com"])
+    runner.invoke(main, ["config", "-su", "picard2305"])
+    runner.invoke(main, ["config", "-sn", "Jean-luc Picard"])
+
+    with open(repo_path / ".dock" / "config.toml", "r") as f:
+        config = tomlkit.parse(f.read())
+
+    assert config["email"] == "picard@gmail.com"
+    assert config["username"] == "picard2305"
+    assert config["name"] == "Jean-luc Picard"
+
+
+def test_set_config_together(init_repo):
+    repo_path = init_repo
+    runner = CliRunner()
+
+    runner.invoke(
+        main,
+        [
+            "config",
+            "-se",
+            "picard@gmail.com",
+            "-su",
+            "picard2305",
+            "-sn",
+            "Jean-luc Picard",
+        ],
+    )
+
+    with open(repo_path / ".dock" / "config.toml", "r") as f:
+        config = tomlkit.parse(f.read())
+
+    assert config["email"] == "picard@gmail.com"
+    assert config["username"] == "picard2305"
+    assert config["name"] == "Jean-luc Picard"
+
+
+def test_update_config_keys(init_repo):
+    repo_path = init_repo
+    runner = CliRunner()
+
+    config_path = repo_path / ".dock" / "config.toml"
+    with open(config_path, "r") as f:
+        config = tomlkit.parse(f.read())
+
+    config["username"] = "chrispike"
+    config["email"] = "chris.pike@gmail.com"
+
+    with open(config_path, "w") as f:
+        tomlkit.dump(config, f)
+
+    runner.invoke(main, ["config", "-su", "picard"])
+    runner.invoke(main, ["config", "-se", "picard@gmail.com"])
+
+    with open(config_path, "r") as f:
+        config = tomlkit.parse(f.read())
+
+    assert config["username"] == "picard"
+    assert config["email"] == "picard@gmail.com"
+
+
+def test_config_cmd_errors_when_config_missing(init_repo):
+    repo_path = init_repo
+    runner = CliRunner()
+
+    config_path = repo_path / ".dock" / "config.toml"
+    if config_path.exists():
+        os.remove(config_path)
+
+    result = runner.invoke(main, ["config", "-su", "picard2305"])
+    assert result.exit_code == 0
+    assert "[ERROR] Spacedock is not initialized. No .dock/ found." in result.output

--- a/tests/test_starlog.py
+++ b/tests/test_starlog.py
@@ -16,6 +16,7 @@ def test_starlog_command(tmp_path):
     (repo / ".conf").mkdir(parents=True, exist_ok=True)
     (repo / ".conf" / "config.py").write_text("set_key=7ash2bs23basd")
     runner.invoke(main, ["beam", "file1.txt", ".conf/config.py"])
+    runner.invoke(main, ["config", "-sn", "Jean-luc picard", "-se", "picard@gmail.com"])
 
     # Run starlog
     result = runner.invoke(main, ["starlog", "-cm", "Test commit"])
@@ -28,3 +29,21 @@ def test_starlog_command(tmp_path):
     # Check stage file is cleared
     with open(repo / ".dock" / "stage") as f:
         assert json.load(f) == []
+
+
+def test_starlog_requires_name_and_email(tmp_path):
+    repo_path = tmp_path / "repo"
+    os.makedirs(repo_path)
+    os.chdir(repo_path)
+    runner = CliRunner()
+    runner.invoke(main, ["start", str(repo_path)])
+
+    (repo_path / "file1.txt").write_text("hello")
+    runner.invoke(main, ["beam", "file1.txt"])
+
+    result = runner.invoke(main, ["starlog", "-cm", "init"])
+
+    assert (
+        "[ERROR] Please set name and email for starlogs\n"
+        " (Use ruxpy config -sn <name> -se <email>)" in result.output
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -616,6 +616,8 @@ dependencies = [
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "toml" },
+    { name = "tomlkit" },
 ]
 
 [package.metadata]
@@ -625,6 +627,17 @@ requires-dist = [
     { name = "flake8", specifier = ">=5.0.4" },
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "toml", specifier = ">=0.10.2" },
+    { name = "tomlkit", specifier = ">=0.13.3" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
 ]
 
 [[package]]
@@ -664,6 +677,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
- Implements `ruxpy config` CLI command to set user metadata (username, email, name) in `.dock/config.toml`
- Uses tomlkit for parsing and writing config, preserving comments and formatting
- Handles missing or corrupted config files gracefully, with clear error messages
- Updates only specified fields, leaving others unchanged
- Provides user feedback on success and error conditions
- Starlog checks config metadata before making starlog entry

## Testing
- Adds tests for setting config fields individually and together.
- Tests error handling for missing config file.
- Ensures config updates are reflected in the TOML file.
- Ensures starlog doesn't make an entry without config metadata

Closes #2 