### PR TITLE
feat: add course command to list local courses/branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +41,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cpufeatures"
@@ -91,6 +103,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +126,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -155,6 +195,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -270,6 +316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "regex-automata"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,12 +339,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ruxpy"
 version = "0.1.0"
 dependencies = [
  "ignore",
  "pyo3",
  "sha3",
+ "tempfile",
  "walkdir",
 ]
 
@@ -362,6 +428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +475,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,3 +515,9 @@ checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ crate-type = ["cdylib"]
 ignore = "0.4.23"
 pyo3 = "0.25.0"
 sha3 = "0.10.8"
+tempfile = "3.23.0"
 walkdir = "2.5.0"

--- a/ruxpy/__init__.py
+++ b/ruxpy/__init__.py
@@ -28,6 +28,7 @@ from .ruxpy import (
     find_dock_root,
     list_all_files,
     filter_ignored_files,
+    get_courses_and_current,
 )
 
 __all__ = [
@@ -39,6 +40,7 @@ __all__ = [
     "find_dock_root",
     "list_all_files",
     "filter_ignored_files",
+    "get_courses_and_current",
     # Python utils
     "read_config",
     "write_config",

--- a/ruxpy/cli.py
+++ b/ruxpy/cli.py
@@ -4,6 +4,7 @@ from .config import config
 from .start import start
 from .scan import scan
 from .beam import beam
+from .course import course
 
 
 @click.group()
@@ -18,6 +19,7 @@ main.add_command(config)
 main.add_command(start)
 main.add_command(scan)
 main.add_command(beam)
+main.add_command(course)
 
 
 if __name__ == "__main__":

--- a/ruxpy/course.py
+++ b/ruxpy/course.py
@@ -1,0 +1,36 @@
+import os
+import click
+from ruxpy import (
+    find_dock_root_py,
+    get_paths,
+    check_spacedock,
+    get_courses_and_current,
+    echo_error,
+)
+
+
+@click.command()
+def course():
+    dock_root = find_dock_root_py()
+    if dock_root is None:  # Not a ruxpy repository
+        echo_error("The spacedock is not initialized. " "Please run 'ruxpy start'")
+        return
+    else:
+        paths = get_paths(dock_root)
+        is_proper = check_spacedock(paths)
+        if not is_proper:
+            echo_error("The spacedock is corrupted. " "Please run 'ruxpy start'")
+            return
+
+    (courses, current) = get_courses_and_current(
+        os.path.join(paths["links"], "helm"), paths["helm"]
+    )
+
+    label = "[On Course] =>"
+    padding = " " * (len(label) + 1)
+    for course in courses:
+        if course == current:
+            click.echo(f"{click.style(label, fg="green")} {course}")
+            continue
+
+        click.echo(f"{padding}{course}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -207,3 +207,21 @@ def test_config_cmd_errors_when_config_missing(init_repo):
     result = runner.invoke(main, ["config", "-su", "picard2305"])
     assert result.exit_code == 0
     assert "[ERROR] Spacedock is not initialized. No .dock/ found." in result.output
+
+
+def test_course_lists_courses_and_current(init_repo):
+    repo_path = init_repo
+    helm = repo_path / ".dock" / "links" / "helm"
+    (helm / "feat-x").write_text("dummyhash1")
+    (helm / "bugfix").write_text("dummyhash2")
+    (helm / "main").write_text("dummyhash3")
+
+    (repo_path / ".dock" / "HELM").write_text("link: links/helm/feat-x")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["course"])
+
+    assert "[On Course] => feat-x" in result.output
+    assert "core" in result.output
+    assert "bugfix" in result.output
+    assert "main" in result.output


### PR DESCRIPTION
## Description
This PR enhances the cli by adding a new command which can be invoked by `ruxpy course` and will list the local course names.

## Main changes
- Adds Cargo dependency `tempfile` for usage in rust lib unit tests
- Adds utilities in rust lib for listing course names from `.dock/links/helm/` and getting the current course name using `HELM` file
- Adds unit tests in rust lib
- Exposes the utilities using pyo3 pyfunction
- The cli adds a new file for course command `course.py` that checks the spacedock and pretty prints the results
- The new command implementation is tested using pytests

Closes #14 